### PR TITLE
Fixing TCP sockets not closing properly on Windows

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -9,7 +9,7 @@ fn main() {
     let handle = event_loop.handle();
 
     let read_file = || {
-        let content = std::fs::read_to_string("./examples/async_tasks.rs").unwrap();
+        let content = std::fs::read_to_string("./examples/async.rs").unwrap();
         Some(Ok(content.as_bytes().to_vec()))
     };
 


### PR DESCRIPTION
This PR:
- Updates the async example.
- Changes how we read bytes from the TCP socket.
- Probably fixes an issue with sockets not closing properly on Windows (sometimes).