### PR TITLE
Switching to rayon for multi-threading tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+  cargo-lint:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+  test:
+    name: Test Suite
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "downcast-rs"
@@ -27,8 +76,14 @@ dependencies = [
  "anyhow",
  "downcast-rs",
  "mio",
- "threadpool",
+ "rayon",
 ]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "hermit-abi"
@@ -55,6 +110,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,13 +141,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
+name = "rayon"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
  "num_cpus",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.58"
-threadpool = "1.8.1"
+rayon = "1.6.1"
 downcast-rs = { version = "1.2.0", default-features = false }
 mio = { version = "0.8.4", features = ["os-poll", "net"] }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This library is a multi-platform support library with a focus on asynchronous I/O. It was primarily developed for use by [Dune](https://github.com/aalykiot/dune), but can be also used in any Rust project.
 
+![GitHub](https://img.shields.io/github/license/aalykiot/dune-event-loop?style=flat-square)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/aalykiot/dune-event-loop/ci.yml?branch=main&style=flat-square)
+
 ## Features
 
 - Timers

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This library is a multi-platform support library with a focus on asynchronous I/
 
 ```rust
 fn main() {
-    let mut event_loop = EventLoop::new();
+    let mut event_loop = EventLoop::default();
     let handle = event_loop.handle();
 
     handle.timer(1000, false, |h: LoopHandle| {
@@ -32,7 +32,7 @@ This library also provides a **thread-pool** which can be used to run user code 
 
 ```rust
 fn main() {
-    let mut event_loop = EventLoop::new();
+    let mut event_loop = EventLoop::default();
     let handle = event_loop.handle();
 
     let read_file = || {
@@ -58,7 +58,7 @@ fn main() {
 
 ```rust
 fn main() {
-    let mut event_loop = EventLoop::new();
+    let mut event_loop = EventLoop::default();
     let handle = event_loop.handle();
 
     let on_close = |_: LoopHandle| println!("Connection closed.");

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -5,7 +5,7 @@ use ev_loop::LoopHandle;
 use ev_loop::TaskResult;
 
 fn main() {
-    let mut event_loop = EventLoop::new();
+    let mut event_loop = EventLoop::default();
     let handle = event_loop.handle();
 
     let read_file = || {

--- a/examples/tcp_echo.rs
+++ b/examples/tcp_echo.rs
@@ -7,7 +7,7 @@ use ev_loop::LoopHandle;
 use ev_loop::TcpSocketInfo;
 
 fn main() {
-    let mut event_loop = EventLoop::new();
+    let mut event_loop = EventLoop::default();
     let handle = event_loop.handle();
 
     let on_close = |_: LoopHandle| println!("Connection closed.");

--- a/examples/tcp_request.rs
+++ b/examples/tcp_request.rs
@@ -7,7 +7,7 @@ use ev_loop::LoopHandle;
 use ev_loop::TcpSocketInfo;
 
 fn main() {
-    let mut event_loop = EventLoop::new();
+    let mut event_loop = EventLoop::default();
     let handle = event_loop.handle();
 
     let on_close = |_: LoopHandle| println!("Connection closed.");

--- a/examples/timers.rs
+++ b/examples/timers.rs
@@ -4,7 +4,7 @@ use ev_loop::EventLoop;
 use ev_loop::LoopHandle;
 
 fn main() {
-    let mut event_loop = EventLoop::new();
+    let mut event_loop = EventLoop::default();
     let handle = event_loop.handle();
 
     handle.timer(1000, false, |h: LoopHandle| {


### PR DESCRIPTION
This PR:
- Uses the rayon crate for the event loop's multi-threading tasks.
- Adds a GitHub CI workflow