### PR TITLE
Improving execution of network operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,14 +100,14 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -128,7 +134,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -158,7 +164,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -200,20 +206,21 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.0.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.1",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
+ "log",
  "mio",
  "walkdir",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -250,11 +257,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -335,24 +342,63 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -362,9 +408,15 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -374,9 +426,15 @@ checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -386,9 +444,15 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -398,15 +462,27 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -416,6 +492,12 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ anyhow = "1.0.58"
 rayon = "1.6.1"
 downcast-rs = { version = "1.2.0", default-features = false }
 mio = { version = "0.8.4", features = ["os-poll", "net"] }
-notify = "5.0.0"
+notify = "6.1.1"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ This library is a multi-platform support library with a focus on asynchronous I/
 ## Features
 
 - Timers
-- Thread pool
 - Asynchronous TCP sockets
+- Thread pool
+- File system events
 
 ## Documentation
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,7 @@ impl EventLoop {
         for event in &events {
             // Note: Token(0) is a special token signaling that someone woke us up.
             if event.token() == Token(0) {
-                break;
+                continue;
             }
 
             let event_type = match (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,7 +505,7 @@ impl EventLoop {
         if let Some(on_connection) = tcp_wrap.on_connection.take() {
             // Run socket's on_connection callback.
             (on_connection)(
-                handle,
+                handle.clone(),
                 index,
                 Ok(TcpSocketInfo {
                     id: index,
@@ -519,8 +519,6 @@ impl EventLoop {
             self.network_events
                 .reregister(&mut tcp_wrap.socket, token, Interest::READABLE)
                 .unwrap();
-
-            return;
         }
 
         loop {
@@ -833,7 +831,7 @@ impl EventLoop {
         // Push data to socket's write queue.
         tcp_wrap.write_queue.push_back((data, on_write));
 
-        let interest = Interest::WRITABLE | Interest::READABLE;
+        let interest = Interest::READABLE.add(Interest::WRITABLE);
 
         self.network_events
             .reregister(&mut tcp_wrap.socket, token, interest)
@@ -856,7 +854,7 @@ impl EventLoop {
 
         let interest = match tcp_wrap.write_queue.len() {
             0 => Interest::READABLE,
-            _ => Interest::READABLE | Interest::WRITABLE,
+            _ => Interest::READABLE.add(Interest::WRITABLE),
         };
 
         self.network_events

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use anyhow::Result;
 use downcast_rs::impl_downcast;
 use downcast_rs::Downcast;
@@ -369,7 +370,12 @@ impl EventLoop {
         let mut events = Events::with_capacity(1024);
 
         // Poll for new network events (this will block the thread).
-        self.poll.poll(&mut events, timeout).unwrap();
+        if let Err(e) = self.poll.poll(&mut events, timeout) {
+            match e.kind() {
+                io::ErrorKind::Interrupted => return,
+                _ => panic!("{}", e),
+            };
+        }
 
         for event in &events {
             // Note: Token(0) is a special token signaling that someone woke us up.
@@ -517,16 +523,38 @@ impl EventLoop {
             return;
         }
 
-        // Connection is OK, let's write some bytes...
-        let (data, on_write) = match tcp_wrap.write_queue.pop_front() {
-            Some(value) => value,
-            None => return,
-        };
+        loop {
+            // Due to loop ownership issues we need to clone the handle.
+            let handle = handle.clone();
 
-        match tcp_wrap.socket.write(&data) {
-            Ok(n) => (on_write)(handle, index, Result::Ok(n)),
-            Err(err) => (on_write)(handle, index, Result::Err(err.into())),
-        };
+            // Connection is OK, let's write some bytes...
+            let (data, on_write) = match tcp_wrap.write_queue.pop_front() {
+                Some(value) => value,
+                None => break,
+            };
+
+            match tcp_wrap.socket.write(&data) {
+                // We want to write the entire `data` buffer in a single go. If we
+                // write less we'll return a short write error (same as
+                // `io::Write::write_all` does).
+                Ok(n) if n < data.len() => {
+                    let err = anyhow!("{}", io::ErrorKind::WriteZero.to_string());
+                    (on_write)(handle, index, Result::Err(err))
+                }
+                // All bytes were written to socket.
+                Ok(n) => (on_write)(handle, index, Result::Ok(n)),
+                // Would block "errors" are the OS's way of saying that the
+                // connection is not actually ready to perform this I/O operation.
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                    // We need to put the data buffer back.
+                    tcp_wrap.write_queue.push_front((data, on_write));
+                    break;
+                }
+                Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+                // An important error seems to have accrued.
+                Err(err) => (on_write)(handle, index, Result::Err(err.into())),
+            };
+        }
 
         // Unregister write interest if the write_queue is empty.
         if tcp_wrap.write_queue.is_empty() {
@@ -592,6 +620,11 @@ impl EventLoop {
             Some(on_read) => on_read,
             None if !connection_closed => return,
             None => {
+                // Deregister any interest on that socket.
+                self.network_events
+                    .deregister(&mut tcp_wrap.socket)
+                    .unwrap();
+                // Schedule resource clean-up.
                 self.close_queue.push((index, None));
                 return;
             }
@@ -637,50 +670,60 @@ impl EventLoop {
         };
 
         let on_connection = tcp_wrap.on_connection.as_mut();
+        let mut resources = vec![];
 
-        // Received an event for the TCP server socket, which indicates we can accept a connection.
-        let (socket, _) = match tcp_wrap.socket.accept() {
-            Ok(sock) => sock,
-            // If we get a `WouldBlock` error we know our
-            // listener has no more incoming connections queued,
-            // so we can return to polling and wait for some
-            // more.
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => return,
-            Err(e) => {
-                (on_connection)(handle, index, Result::Err(e.into()));
-                return;
-            }
-        };
+        loop {
+            // Create a new handle.
+            let handle = handle.clone();
 
-        // Create a new ID for the socket.
-        let id = handle.index();
+            // Received an event for the TCP server socket, which indicates we can accept a connections.
+            let (socket, _) = match tcp_wrap.socket.accept() {
+                Ok(sock) => sock,
+                // If we get a `WouldBlock` error we know our
+                // listener has no more incoming connections queued,
+                // so we can return to polling and wait for some
+                // more.
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
+                Err(e) => {
+                    (on_connection)(handle, index, Result::Err(e.into()));
+                    break;
+                }
+            };
 
-        // Create a TCP wrap from the raw socket.
-        let mut stream = TcpStreamWrap {
-            id,
-            socket,
-            on_connection: None,
-            on_read: None,
-            write_queue: LinkedList::new(),
-        };
+            // Create a new ID for the socket.
+            let id = handle.index();
 
-        (on_connection)(
-            handle,
-            id,
-            Ok(TcpSocketInfo {
+            // Create a TCP wrap from the raw socket.
+            let mut stream = TcpStreamWrap {
                 id,
-                host: stream.socket.local_addr().unwrap(),
-                remote: stream.socket.peer_addr().unwrap(),
-            }),
-        );
+                socket,
+                on_connection: None,
+                on_read: None,
+                write_queue: LinkedList::new(),
+            };
 
-        // Initialize socket with a READABLE event.
-        self.network_events
-            .register(&mut stream.socket, Token(id as usize), Interest::READABLE)
-            .unwrap();
+            (on_connection)(
+                handle,
+                id,
+                Ok(TcpSocketInfo {
+                    id,
+                    host: stream.socket.local_addr().unwrap(),
+                    remote: stream.socket.peer_addr().unwrap(),
+                }),
+            );
 
-        // Register the new TCP stream to the event-loop.
-        self.resources.insert(id, Box::new(stream));
+            // Initialize socket with a READABLE event.
+            self.network_events
+                .register(&mut stream.socket, Token(id as usize), Interest::READABLE)
+                .unwrap();
+
+            resources.push((id, Box::new(stream)));
+        }
+
+        for (id, stream) in resources.drain(..) {
+            // Register the new TCP stream to the event-loop.
+            self.resources.insert(id, stream);
+        }
     }
 
     /// Runs callback referring to specific fs event.
@@ -1122,6 +1165,7 @@ impl LoopHandle {
     }
 }
 
+#[derive(Clone)]
 pub struct LoopInterruptHandle {
     waker: Arc<Waker>,
 }


### PR DESCRIPTION
This PR:
- Improves stability when the registry's `poll` method is called.
- Accepts multiple connections (in the same tick) until a `WouldBlock` error is thrown.
- Tries multiple socket writes (in the same tick) until a `WouldBlock` error is thrown.
- Deregisters interest for a socket when the host closes the connection.
- Fixes an issue of ignoring network events if `token(0)` is included in the events vector.