### PR TITLE
Adding support for `Unix` and `Windows` signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "downcast-rs",
+ "libc",
  "mio",
  "notify",
  "rayon",
+ "signal-hook",
+ "signal-hook-mio",
 ]
 
 [[package]]
@@ -170,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "log"
@@ -278,6 +281,36 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +82,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
+dependencies = [
+ "nix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,8 +102,8 @@ name = "dune_event_loop"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ctrlc",
  "downcast-rs",
- "libc",
  "mio",
  "notify",
  "rayon",
@@ -205,6 +221,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "autocfg"
@@ -139,15 +139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,14 +204,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.36.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -255,20 +246,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -276,14 +257,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -390,19 +369,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -463,12 +429,6 @@ checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -478,12 +438,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -499,12 +453,6 @@ checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -514,12 +462,6 @@ name = "windows_i686_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -544,12 +486,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,22 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+libc = "0.2.153"
 anyhow = "1.0.58"
 rayon = "1.6.1"
 downcast-rs = { version = "1.2.0", default-features = false }
 mio = { version = "0.8.4", features = ["os-poll", "net"] }
 notify = "6.1.1"
+
+[dependencies.signal-hook]
+version = "0.3.17"
+default-features = false
+features = ["channel"]
+
+[target.'cfg(unix)'.dependencies.signal-hook]
+version = "0.3.17"
+default-features = false
+features = ["channel", "iterator"]
+
+[target.'cfg(unix)'.dependencies]
+signal-hook-mio = { version = "0.2.3", features = ["support-v0_8"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.58"
-rayon = "1.6.1"
+anyhow = "1.0.81"
+rayon = "1.10.0"
 downcast-rs = { version = "1.2.0", default-features = false }
-mio = { version = "0.8.4", features = ["os-poll", "net"] }
+mio = { version = "0.8.11", features = ["os-poll", "net"] }
 notify = "6.1.1"
 
 [dependencies.signal-hook]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = "0.2.153"
 anyhow = "1.0.58"
 rayon = "1.6.1"
 downcast-rs = { version = "1.2.0", default-features = false }
@@ -30,3 +29,6 @@ features = ["channel", "iterator"]
 
 [target.'cfg(unix)'.dependencies]
 signal-hook-mio = { version = "0.2.3", features = ["support-v0_8"] }
+
+[target.'cfg(windows)'.dependencies]
+ctrlc = "3.4.4"

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ For terminating the listener, `signal_stop()` serves as the appropriate function
 ```rust
 let token = handle.signal_start(SIGINT, on_signal).unwrap();
 
-handle.signal_stop(token);
+handle.signal_stop(&token);
 ```
 
 > You can run all the above examples located in `/examples` folders using cargo: `cargo run --example [name]`

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ fn main() {
 > Certain signals, such as `SIGKILL` or `SIGSTOP`, cannot be overridden or subscribed to. Additionally, on the Windows platform, only `SIGINT` is supported.
 
 ```rust
-    fn main() {
+fn main() {
     let mut event_loop = EventLoop::default();
     let handle = event_loop.handle();
     let ctrl_c = Rc::new(Cell::new(false));

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ This library is a multi-platform support library with a focus on asynchronous I/
 - Asynchronous TCP sockets
 - Thread pool
 - File system events
+- Signals
 
 ## Documentation
 
-**Timer** handles are used to schedule callbacks to be called in the future.
+**Timer handles** are used to schedule callbacks to be called in the future.
 
 ```rust
 fn main() {
@@ -132,6 +133,48 @@ fn main() {
         event_loop.tick();
     }
 }
+```
+
+**Signal handles** are wrappers around UNIX signals with some Windows support as well.
+
+> Certain signals, such as `SIGKILL` or `SIGSTOP`, cannot be overridden or subscribed to. Additionally, on the Windows platform, only `SIGINT` is supported.
+
+```rust
+    fn main() {
+    let mut event_loop = EventLoop::default();
+    let handle = event_loop.handle();
+    let ctrl_c = Rc::new(Cell::new(false));
+
+    // Exit the program on double CTRL+C.
+    let on_signal = move |_: LoopHandle, _: i32| {
+        match ctrl_c.get() {
+            true => std::process::exit(0),
+            false => ctrl_c.set(true),
+        };
+    };
+
+    handle.signal_start(SIGINT, on_signal).unwrap();
+
+    loop {
+        // We need somehow to keep the program running cause signal
+        // listeners wont keep the event-loop alive.
+        event_loop.tick();
+    }
+}
+```
+
+To create one-time signal handles, utilize the `signal_start_oneshot()` function.
+
+```rust
+handle.signal_start_oneshot(SIGINT, on_signal).unwrap();
+```
+
+For terminating the listener, `signal_stop()` serves as the appropriate function.
+
+```rust
+let token = handle.signal_start(SIGINT, on_signal).unwrap();
+
+handle.signal_stop(token);
 ```
 
 > You can run all the above examples located in `/examples` folders using cargo: `cargo run --example [name]`

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -1,0 +1,24 @@
+extern crate dune_event_loop as ev_loop;
+
+use ev_loop::EventLoop;
+use ev_loop::LoopHandle;
+use signal_hook::consts::SIGINT;
+
+fn main() {
+    let mut event_loop = EventLoop::default();
+    let handle = event_loop.handle();
+
+    handle.timer(100000, false, |_: LoopHandle| {
+        println!("Hello!");
+    });
+
+    let on_signal = |_: LoopHandle, _: i32| {
+        println!("Signal detected!");
+    };
+
+    handle.signal_start(SIGINT, on_signal).unwrap();
+
+    while event_loop.has_pending_events() {
+        event_loop.tick();
+    }
+}

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -4,12 +4,11 @@ use ev_loop::EventLoop;
 use ev_loop::LoopHandle;
 use ev_loop::Signal::SIGINT;
 use std::cell::Cell;
-use std::rc::Rc;
 
 fn main() {
     let mut event_loop = EventLoop::default();
     let handle = event_loop.handle();
-    let ctrl_c = Rc::new(Cell::new(false));
+    let ctrl_c = Cell::new(false);
 
     // Exit the program on double CTRL+C.
     let on_signal = move |_: LoopHandle, _: i32| {

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -12,11 +12,11 @@ fn main() {
         println!("Hello!");
     });
 
-    let on_signal = |_: LoopHandle, _: i32| {
+    let on_signal = move |_: LoopHandle, _: i32| {
         println!("Signal detected!");
     };
 
-    handle.signal_start(SIGINT, on_signal).unwrap();
+    handle.signal_start_oneshot(SIGINT, on_signal).unwrap();
 
     while event_loop.has_pending_events() {
         event_loop.tick();

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -13,7 +13,7 @@ fn main() {
     });
 
     let on_signal = move |_: LoopHandle, _: i32| {
-        println!("Signal detected!");
+        println!("Ctrl+C pressed!");
     };
 
     handle.signal_start_oneshot(SIGINT, on_signal).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@ type SignalHandler = Box<dyn FnMut(LoopHandle, i32) + 'static>;
 
 /// Abstracts signal handling across platforms.
 struct OsSignals {
+    #[cfg(target_family = "unix")]
     sources: Signals,
     handlers: HashMap<i32, Vec<SignalWrap>>,
 }
@@ -185,7 +186,6 @@ impl OsSignals {
         ctrlc::set_handler(on_signal_handler).unwrap();
 
         OsSignals {
-            sources: Signals::new::<[_; 0], i32>([]).unwrap(),
             handlers: HashMap::new(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,8 +505,8 @@ impl EventLoop {
 
     /// Polls for new I/O events (async-tasks, networking, etc).
     fn run_poll(&mut self) {
-        // Based on what resources the event-loop is currently running will decide
-        // how long we should wait on the this phase.
+        // Based on what resources the event-loop is currently running will
+        // decide how long we should wait on the this phase.
         let timeout = if self.has_pending_events() {
             let refs = self.check_queue.len() + self.close_queue.len();
             match self.timer_queue.iter().next() {


### PR DESCRIPTION
- In UNIX platforms most [signals](https://docs.rs/signal-hook/latest/signal_hook/consts/signal/index.html) are supported.
- In Windows only `SIGINT` is supported.