### PR TITLE
Fixing `tcp_shutdown` functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dune_event_loop"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dune_event_loop"
 description = "A multi-platform event loop library 🎡"
 authors = ["Alex Alikiotis <alexalikiotis5@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 repository = "https://gitlab.com/aalykiot/ev_loop"
 license = "MIT"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dune_event_loop"
-description = "Dune's event-loop library used for timers, async tasks and TCP connections"
+description = "A multi-platform event loop library 🎡"
 authors = ["Alex Alikiotis <alexalikiotis5@gmail.com>"]
 version = "0.1.0"
 repository = "https://gitlab.com/aalykiot/ev_loop"


### PR DESCRIPTION
This PR:
- Updates project's description.
- Fixes the behaviour of `tcp_shutdown` by passing a callback function to the call.